### PR TITLE
chore: Add hadolint CI for Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+orbs:
+  docker: circleci/docker@2.0.3
+workflows:
+  lint:
+    jobs:
+      - docker/hadolint:
+          dockerfiles: 'bcc-centos7/Dockerfile:ci-env/Dockerfile:clang-format-3.9/Dockerfile:pegasus-build-env/centos7/Dockerfile:pegasus-build-env/ubuntu1604/Dockerfile:pegasus-build-env/ubuntu1804/Dockerfile:pegasus-build-env/ubuntu2004/Dockerfile:pegasus-docker-compose/image_for_prebuilt_bin/Dockerfile:thirdparties-bin/Dockerfile:thirdparties-src/Dockerfile'
+          ignore-rules: 'DL3033,DL3013,DL3059,SC2086,DL3003,SC2164,DL3008,DL3007,DL3006'

--- a/bcc-centos7/Dockerfile
+++ b/bcc-centos7/Dockerfile
@@ -20,26 +20,26 @@ FROM centos:7.5.1804 as builder
 LABEL maintainer=wutao
 
 RUN yum install -y epel-release \
-&& yum update -y \
-&& yum groupinstall -y "Development tools" \
-&& yum install -y elfutils-libelf-devel git bison flex ncurses-devel python3 \
-&& yum install -y luajit luajit-devel \
-&& yum -y install centos-release-scl \
-&& yum-config-manager --enable rhel-server-rhscl-7-rpms \
-&& yum install -y devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-devel llvm-toolset-7-llvm-static llvm-toolset-7-clang-devel \
-&& yum clean all \
-&& rm -rf /var/cache/yum;
+  && yum update -y \
+  && yum groupinstall -y "Development tools" \
+  && yum install -y elfutils-libelf-devel git bison flex ncurses-devel python3 \
+  && yum install -y luajit luajit-devel \
+  && yum -y install centos-release-scl \
+  && yum-config-manager --enable rhel-server-rhscl-7-rpms \
+  && yum install -y devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-devel llvm-toolset-7-llvm-static llvm-toolset-7-clang-devel \
+  && yum clean all \
+  && rm -rf /var/cache/yum;
 
 RUN pip3 install --no-cache-dir cmake
 
 # install results to /root/bcc
 RUN git clone https://github.com/iovisor/bcc.git \
-&& cd bcc \
-&& source scl_source enable devtoolset-7 llvm-toolset-7 \
-&& cmake -B build/ . \
-&& cmake --build build/ -j $(($(nproc)/2+1)) \
-&& cmake --install build/ --prefix $HOME/bcc \
-&& rm -rf /bcc
+  && cd bcc \
+  && source scl_source enable devtoolset-7 llvm-toolset-7 \
+  && cmake -B build/ . \
+  && cmake --build build/ -j $(($(nproc)/2+1)) \
+  && cmake --install build/ --prefix $HOME/bcc \
+  && rm -rf /bcc
 
 FROM centos:7.5.1804
 

--- a/clang-format-3.9/Dockerfile
+++ b/clang-format-3.9/Dockerfile
@@ -21,8 +21,8 @@ LABEL maintainer=wutao
 
 RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/' /etc/apt/sources.list \
     && apt-get update -y \
-    && apt-get install -y software-properties-common \
+    && apt-get install --no-install-recommends -y software-properties-common \
     && add-apt-repository ppa:git-core/ppa \
     && apt-get update -y \
-    && apt-get -y install clang-format-3.9 git \
+    && apt-get install --no-install-recommends -y clang-format-3.9 git \
     && rm -rf /var/lib/apt/lists/*

--- a/pegasus-build-env/centos7/Dockerfile
+++ b/pegasus-build-env/centos7/Dockerfile
@@ -58,7 +58,7 @@ rm -rf /var/cache/yum;
 
 RUN pip3 install --no-cache-dir cmake
 
-RUN wget https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven \
+RUN wget --progress=dot:giga https://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz -P /opt/maven \
     && cd /opt/maven \
     && tar -zxf apache-maven-3.8.3-bin.tar.gz \
     && rm apache-maven-3.8.3-bin.tar.gz

--- a/pegasus-build-env/ubuntu1604/Dockerfile
+++ b/pegasus-build-env/ubuntu1604/Dockerfile
@@ -23,7 +23,8 @@ ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y; \
-    apt-get -y install build-essential \
+    apt-get install -y --no-install-recommends \
+                       build-essential \
                        software-properties-common \
                        openjdk-8-jdk \
                        python3-pip \
@@ -55,8 +56,7 @@ RUN apt-get update -y; \
 
 RUN add-apt-repository ppa:git-core/ppa -y; \
     apt-get update -y; \
-    apt-get install git -y; \
-    apt-get install pkg-config -y; \
+    apt-get install git pkg-config -y --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir cmake

--- a/pegasus-build-env/ubuntu1804/Dockerfile
+++ b/pegasus-build-env/ubuntu1804/Dockerfile
@@ -23,7 +23,8 @@ ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y; \
-    apt-get -y install build-essential \
+    apt-get install -y --no-install-recommends \
+                       build-essential \
                        software-properties-common \
                        clang-9 \
                        openjdk-8-jdk \
@@ -56,8 +57,8 @@ RUN apt-get update -y; \
 
 RUN add-apt-repository ppa:git-core/ppa -y; \
     apt-get update -y; \
-    apt-get install git -y; \
-    apt-get install pkg-config -y; \
+    apt-get install git -y --no-install-recommends; \
+    apt-get install pkg-config -y --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir cmake

--- a/pegasus-build-env/ubuntu2004/Dockerfile
+++ b/pegasus-build-env/ubuntu2004/Dockerfile
@@ -23,7 +23,8 @@ ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update -y; \
-    apt-get -y install build-essential \
+    apt-get install -y --no-install-recommends \
+                       build-essential \
                        software-properties-common \
                        clang-10 \
                        openjdk-8-jdk \
@@ -56,8 +57,8 @@ RUN apt-get update -y; \
 
 RUN add-apt-repository ppa:git-core/ppa -y; \
     apt-get update -y; \
-    apt-get install git -y; \
-    apt-get install pkg-config -y; \
+    apt-get install git -y --no-install-recommends; \
+    apt-get install pkg-config -y --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir cmake


### PR DESCRIPTION
https://github.com/hadolint/hadolint is a popular linter to check Dockerfile.
This patch add hadolint Ci via circleci (This is the only CI system I found to check multiple Dockerfiles)
There are many issues checked out by hadolint, I left them and add some ignore-rules, we can discuss and fix them in the future.